### PR TITLE
Support PKCE with redirect based authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1411,9 +1411,9 @@
       "optional": true
     },
     "@criipto/auth-js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-2.2.1.tgz",
-      "integrity": "sha512-T3pYi0yvCS/MrIppLBcKabbC+Cyomk0Md8EeNInUtiMxJn68bN9UI6kiz4yJsEMlmP5NHKVdlN0rCOMv6vdOyA=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-2.7.0.tgz",
+      "integrity": "sha512-dOEoLXIzplH6Dl9XU6H7xt/pwlriFknZQSVCbchaOlKeFUZC1K35R1l2wZwiemWoH6CVjWSizlnXIoRYN+QWMw=="
     },
     "@design-systems/utils": {
       "version": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   },
   "homepage": "https://github.com/criipto/criipto-verify-react#readme",
   "dependencies": {
-    "@criipto/auth-js": "^2.2.1"
+    "@criipto/auth-js": "^2.7.0"
   }
 }

--- a/src/components/AuthMethodButton/AuthMethodButton.stories.tsx
+++ b/src/components/AuthMethodButton/AuthMethodButton.stories.tsx
@@ -27,7 +27,13 @@ export default {
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof AuthMethodButton> = (args, {globals}) => {
   return (
-    <CriiptoVerifyProvider completionStrategy={(args as any).completionStrategy} response={(args as any).response} domain={globals.domain} clientID={globals.clientID} redirectUri="https://httpbin.org/get">
+    <CriiptoVerifyProvider
+      completionStrategy={(args as any).completionStrategy}
+      response={(args as any).response}
+      domain={globals.domain}
+      clientID={globals.clientID}
+      redirectUri={window.location.href}
+    >
       <StoryResponseRenderer>
         <AuthMethodButton {...args}>
           {acrValueToTitle('en', args.acrValue).title}<br />
@@ -43,3 +49,10 @@ SEBankIDSameDeviceButton.args = {
   acrValue: 'urn:grn:authn:se:bankid:same-device'
 };
 SEBankIDSameDeviceButton.storyName = "se:bankid:same-device";
+
+
+export const DKMitID = Template.bind({});
+DKMitID.args = {
+  acrValue: 'urn:grn:authn:dk:mitid:low'
+};
+DKMitID.storyName = "dk:mitid:low";

--- a/src/components/AuthMethodSelector/AuthMethodSelector.stories.tsx
+++ b/src/components/AuthMethodSelector/AuthMethodSelector.stories.tsx
@@ -71,7 +71,14 @@ export default {
 
 const Template: ComponentStory<typeof AuthMethodSelector> = (args, {globals}) => {
   return (
-    <CriiptoVerifyProvider completionStrategy={(args as any).completionStrategy} response={(args as any).response} action={(args as any).action} domain={globals.domain} clientID={globals.clientID} redirectUri="https://httpbin.org/get">
+    <CriiptoVerifyProvider
+      completionStrategy={(args as any).completionStrategy}
+      response={(args as any).response}
+      action={(args as any).action}
+      domain={globals.domain}
+      clientID={globals.clientID}
+      redirectUri={window.location.href}
+    >
       <StoryResponseRenderer>
         <AuthMethodSelector {...args}  />
       </StoryResponseRenderer>

--- a/src/components/SEBankIDSameDeviceButton/SEBankIDSameDeviceButton.tsx
+++ b/src/components/SEBankIDSameDeviceButton/SEBankIDSameDeviceButton.tsx
@@ -2,7 +2,6 @@ import { PKCE, AuthorizeResponse } from '@criipto/auth-js';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 import CriiptoVerifyContext from '../../context';
 import { getMobileOS } from '../../device';
-import usePageVisibility from '../../hooks/usePageVisibility';
 
 import Desktop from './Desktop';
 import Android from './Android';
@@ -34,7 +33,7 @@ export default function SEBankIDSameDeviceButton(props: Props) {
   const [error, setError] = useState<string | null>(null);
   const [log, setLog] = useState<(string | string[])[]>([]);
   const [initiated, setInitiated] = useState(autoHydratedState ? true : false);
-  const {buildAuthorizeUrl, completionStrategy, generatePKCE, domain, handleResponse, redirectUri: defaultRedirectURi} = useContext(CriiptoVerifyContext);
+  const {buildAuthorizeUrl, completionStrategy, generatePKCE, handleResponse, redirectUri: defaultRedirectURi} = useContext(CriiptoVerifyContext);
   const redirectUri = props.redirectUri || defaultRedirectURi;
 
   const reset = () => {
@@ -69,7 +68,7 @@ export default function SEBankIDSameDeviceButton(props: Props) {
     await handleResponse(params, {
       pkce: required.pkce,
       redirectUri
-    })
+    });
   }, [completionStrategy, pkce]);
 
   const refresh = useCallback(async () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,8 @@
-import CriiptoAuth, {OpenIDConfiguration, AuthorizeUrlParamsOptional, PKCE, AuthorizeResponse, OAuth2Error} from '@criipto/auth-js';
+import CriiptoAuth, {OpenIDConfiguration, AuthorizeUrlParamsOptional, PKCE, AuthorizeResponse, OAuth2Error, PKCEPublicPart} from '@criipto/auth-js';
 import { RedirectAuthorizeParams } from '@criipto/auth-js/dist/types';
 import { createContext } from 'react';
 
-export type Result = {id_token: string} | {code: string} | OAuth2Error;
+export type Result = {id_token: string, state?: string} | {code: string, state?: string} | OAuth2Error;
 export type Action = 'confirm' | 'accept' | 'approve' | 'sign' | 'login';
 
 export interface CriiptoVerifyContextInterface {
@@ -16,7 +16,10 @@ export interface CriiptoVerifyContextInterface {
   result: Result | null
   domain: string
   redirectUri?: string,
-  action: Action
+  action: Action,
+  pkce?: PKCE | PKCEPublicPart,
+  store: Storage,
+  isLoading: boolean
 }
 
 /**
@@ -39,7 +42,10 @@ const initialContext = {
   completionStrategy: 'client' as 'client' | 'openidprovider',
   result: null,
   domain: '',
-  action: 'login' as Action
+  action: 'login' as Action,
+  pkce: undefined,
+  store: sessionStorage,
+  isLoading: false
 };
 
 const CriiptoVerifyContext = createContext<CriiptoVerifyContextInterface>(initialContext);

--- a/src/stories/StoryResponseRenderer.tsx
+++ b/src/stories/StoryResponseRenderer.tsx
@@ -6,7 +6,12 @@ interface Props {
 }
 
 export default function StoryResponseRenderer(props: Props) : JSX.Element {
-  const {result} = useCriiptoVerify();
+  const {result, isLoading} = useCriiptoVerify();
+
+  if (isLoading) {
+    return <span>'Loading ...'</span>;
+  }
+
   if (result) {
     return (
       <pre>

--- a/src/stories/methods.stories.tsx
+++ b/src/stories/methods.stories.tsx
@@ -58,7 +58,7 @@ function LoginButton(props: any) {
 
 const Template = (args: any, {globals} : any) => {
   return (
-    <CriiptoVerifyProvider action={(args as any).action} domain={globals.domain} clientID={globals.clientID} redirectUri="https://httpbin.org/get">
+    <CriiptoVerifyProvider action={(args as any).action} domain={globals.domain} clientID={globals.clientID}>
       <StoryResponseRenderer>
         <LoginButton acrValues={args.acrValues} />
       </StoryResponseRenderer>

--- a/src/use-criipto-verify.ts
+++ b/src/use-criipto-verify.ts
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import CriiptoVerifyContext from "./context";
 
 export default function useCriiptoVerify() {
-  const {result, loginWithRedirect} = useContext(CriiptoVerifyContext);
+  const {result, loginWithRedirect, isLoading} = useContext(CriiptoVerifyContext);
 
-  return {result, loginWithRedirect};
+  return {result, loginWithRedirect, isLoading};
 }


### PR DESCRIPTION
Will likely need to use "Open canvas in new tab" to test.

Can be tested with the AuthMethodSelector story, the DK MitID story and the `loginWithRedirect` story.