### PR TITLE
Use foreground strateg for iOS Chrome

### DIFF
--- a/src/components/SEBankIDSameDeviceButton.tsx
+++ b/src/components/SEBankIDSameDeviceButton.tsx
@@ -96,7 +96,6 @@ export default function SEBankIDSameDeviceButton(props: Props) {
       setPKCE(pkce || undefined);
       setLinks(links);
 
-      const iOSSafari = mobileOS === 'iOS' && userAgent?.browser.name?.includes('Safari') ? true : false;
       const androidChrome = mobileOS === 'android' && userAgent?.browser.name === 'Chrome' ? true : false;
       const redirect = iOSSafari ? encodeURIComponent(window.location.href) : 'null';
       const useUniveralLink = iOSSafari || androidChrome;

--- a/src/components/SEBankIDSameDeviceButton/Foreground.tsx
+++ b/src/components/SEBankIDSameDeviceButton/Foreground.tsx
@@ -12,21 +12,21 @@ interface Props {
 }
 
 /*
- * Android: Background/Foreground scenario
+ * Android + iOS Chrome: Background/Foreground scenario
  */
-export default function SEBankIDSameDeviceAndroid(props: Props) {
+export default function SEBankIDSameDeviceForeground(props: Props) {
   const {links, onError, onComplete, onInitiate, onLog} = props;
   const [initiated, setInitiated] = useState(false);
 
   usePageVisibility(async () => {
-    onLog('android', 'onForeground', initiated.toString());
+    onLog('ForegroundStrategy', 'onForeground', initiated.toString());
     if (!initiated) return;
     
     onComplete(links.completeUrl);
   }, [links, initiated]);
 
   const handleInitiate = () => {
-    onLog('android', 'handleInitiate');
+    onLog('ForegroundStrategy', 'handleInitiate');
     onInitiate();
     setInitiated(true);
   };

--- a/src/components/SEBankIDSameDeviceButton/Poll.tsx
+++ b/src/components/SEBankIDSameDeviceButton/Poll.tsx
@@ -14,7 +14,7 @@ interface Props {
 /*
  * Desktop: Polling scenario
  */
-export default function SEBankIDSameDeviceDesktop(props: Props) {
+export default function SEBankIDSameDevicePoll(props: Props) {
   const {links, onError, onComplete, onInitiate} = props;
   const [initiated, setInitiated] = useState(false);
   const {domain} = useContext(CriiptoVerifyContext);

--- a/src/components/SEBankIDSameDeviceButton/Reload.tsx
+++ b/src/components/SEBankIDSameDeviceButton/Reload.tsx
@@ -14,13 +14,14 @@ interface Props {
 }
 
 /*
- * iOS: Page reload on switch back scenario
+ * iOS Safari: Page reload on switch back scenario
  */
-export default function SEBankIDSameDeviceIOS(props: Props) {
+
+export default function SEBankIDSameDeviceReload(props: Props) {
   const {links, onError, onComplete, onInitiate, onLog, pkce, redirectUri} = props;
 
   const handleInitiate = () => {
-    onLog('iOS', 'handleInitiate');
+    onLog('ReloadStrategy', 'handleInitiate');
 
     saveState({
       links,

--- a/src/components/SEBankIDSameDeviceButton/__tests__/Reload.test.tsx
+++ b/src/components/SEBankIDSameDeviceButton/__tests__/Reload.test.tsx
@@ -1,8 +1,8 @@
 import renderer from 'react-test-renderer';
-import SEBankIDSameDeviceIOS from '../iOS';
+import ReloadStrategy from '../Reload';
 import { Links, clearState } from '../shared';
 
-describe('SEBankID/SameDevice/iOS', function () {
+describe('SEBankID/SameDevice/ReloadStrategy', function () {
   beforeEach(() => {
     clearState();
   });
@@ -24,7 +24,7 @@ describe('SEBankID/SameDevice/iOS', function () {
     const onComplete = jest.fn();
 
     let component = renderer.create(
-      <SEBankIDSameDeviceIOS
+      <ReloadStrategy
         links={links}
         onError={onError}
         onInitiate={onInitiate}
@@ -34,7 +34,7 @@ describe('SEBankID/SameDevice/iOS', function () {
         pkce={undefined}
       >
           <button>dummy</button>
-      </SEBankIDSameDeviceIOS>
+      </ReloadStrategy>
     );
 
     let tree = component.toJSON();
@@ -47,7 +47,7 @@ describe('SEBankID/SameDevice/iOS', function () {
 
     renderer.act(() => {
       component = renderer.create(
-        <SEBankIDSameDeviceIOS
+        <ReloadStrategy
           links={links}
           onError={onError}
           onInitiate={onInitiate}
@@ -57,7 +57,7 @@ describe('SEBankID/SameDevice/iOS', function () {
           pkce={undefined}
         >
             <button>dummy</button>
-        </SEBankIDSameDeviceIOS>
+        </ReloadStrategy>
       );
     });
 


### PR DESCRIPTION
Switchback to browser will not work for iOS Chrome as it will resume to a seperate tab than the one started in. This commit refactors the device-specific code paths to be 'strategies' instead that can be applied to various UA targets.

Tested on:
- iOS Safari
- iOS Chrome
- Desktop

Please help test on:
- Android Chrome (https://deploy-preview-20--criipto-verify-react-storybook.netlify.app/iframe.html?args=&id=components-authmethodbutton--se-bank-id-same-device-button&viewMode=story)