### PR TITLE
sebankid: always use universal links on iOS browsers

### DIFF
--- a/src/components/SEBankIDSameDeviceButton.tsx
+++ b/src/components/SEBankIDSameDeviceButton.tsx
@@ -1,5 +1,5 @@
 import { PKCE, AuthorizeResponse } from '@criipto/auth-js';
-import React, {useCallback, useContext, useEffect, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import CriiptoVerifyContext from '../context';
 import { getUserAgent } from '../device';
 
@@ -75,15 +75,11 @@ async function fetchComplete(completeUrl: string) {
 }
 export default function SEBankIDSameDeviceButton(props: Props) {
   const {loginHint} = useContext(CriiptoVerifyContext);
-  const userAgent = getUserAgent(typeof navigator !== 'undefined' ? navigator.userAgent : props.userAgent);
-  const mobileOS = userAgent?.os.name === 'iOS' ? 'iOS' : userAgent?.os.name === 'Android' ? 'android' : null;
-  const iOSSafari = mobileOS === 'iOS' && userAgent?.browser.name?.includes('Safari') ? true : false;
-  const iOSWebKit = mobileOS === 'iOS' && userAgent?.browser.name?.includes('WebKit') ? true : false;
-
-  const strategy = determineStrategy(
-    typeof navigator !== 'undefined' ? navigator.userAgent : props.userAgent,
+  const rawUserAgent = typeof navigator !== 'undefined' ? navigator.userAgent : props.userAgent;
+  const strategy = useMemo(() => determineStrategy(
+    rawUserAgent,
     loginHint
-  );
+  ), [rawUserAgent, loginHint]);
 
   const [href, setHref] = useState<null | string>();
   const [links, setLinks] = useState<Links | null>(autoHydratedState?.links ?? null);

--- a/src/components/SEBankIDSameDeviceButton/__tests__/Reload.test.tsx
+++ b/src/components/SEBankIDSameDeviceButton/__tests__/Reload.test.tsx
@@ -8,12 +8,6 @@ describe('SEBankID/SameDevice/ReloadStrategy', function () {
     clearState();
   });
 
-  it('uses reload strategy for iOS safari', function () {
-    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1';
-
-    expect(determineStrategy(userAgent)).toBe('Reload');
-  });
-
   it('calls complete on refresh', function () {
     const links : Links = {
       launchLinks: {

--- a/src/components/SEBankIDSameDeviceButton/__tests__/strategy.test.ts
+++ b/src/components/SEBankIDSameDeviceButton/__tests__/strategy.test.ts
@@ -134,7 +134,6 @@ describe('SEBankID/strategy', function () {
     });
   });
 
-  // Cannot be distinguished from iOS Safari
   it('uses reload strategy for iOS Edge', function () {
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125.0.2535.96 Version/17.0 Mobile/15E148 Safari/604.1';
 

--- a/src/components/SEBankIDSameDeviceButton/__tests__/strategy.test.ts
+++ b/src/components/SEBankIDSameDeviceButton/__tests__/strategy.test.ts
@@ -4,37 +4,71 @@ describe('SEBankID/strategy', function () {
   it('uses reload strategy for iOS safari', function () {
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1';
 
-    expect(determineStrategy(userAgent, undefined)).toBe('Reload');
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Reload',
+      linkType: 'universal',
+      redirect: true
+    });
   });
 
   test('uses reload strategy for iOS Safari (2)', function () {
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
-    expect(determineStrategy(userAgent, undefined)).toBe('Reload');
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Reload',
+      linkType: 'universal',
+      redirect: true
+    });
   })
 
-  test('uses reload strategy for iOS WebKit', function () {
+  test('uses foreground strategy for iOS WebKit', function () {
     // source: Expo WebView
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
-    expect(determineStrategy(userAgent, undefined)).toBe('Reload');
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
   });
 
   it('uses poll strategy for Windows Chrome', function () {
     const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
 
-    expect(determineStrategy(userAgent, undefined)).toBe('Poll');
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Poll',
+      linkType: 'scheme',
+      redirect: false
+    });
   });
 
   it('uses foreground strategy for Android Chrome', function () {
     const userAgent = 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36';
 
-    expect(determineStrategy(userAgent, undefined)).toBe('Foreground');
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
   });
+
+  it('uses foreground strategy for Android Samsung Browser', function () {
+    const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/99.9 Chrome/96.0.4664.104 Safari/537.36';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'scheme',
+      redirect: false
+    });
+  })
 
   it('uses foreground strategy for iOS Safari with resume disabled', function () {
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1';
     const loginHint = 'appswitch:resumeUrl:disable';
 
-    expect(determineStrategy(userAgent, loginHint)).toBe('Foreground');
+    expect(determineStrategy(userAgent, loginHint)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
   });
 
   test('uses reload strategy for iOS WebKit with resume disabled', function () {
@@ -42,6 +76,72 @@ describe('SEBankID/strategy', function () {
     const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
     const loginHint = 'appswitch:resumeUrl:disable';
 
-    expect(determineStrategy(userAgent, loginHint)).toBe('Foreground');
+    expect(determineStrategy(userAgent, loginHint)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
+  });
+
+  it('uses foreground strategy for iOS Instagram', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21F90 Instagram 335.1.8.26.85 (iPhone14,3; iOS 17_5_1; da_DK; da; scale=3.00; 1284x2778; 609775437) NW/3';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
+  });
+
+  it('uses foreground strategy for iOS Chrome', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 Mobile/15E148 Safari/604.1';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
+  });
+
+  it('uses foreground strategy for iOS Firefox', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/127.0  Mobile/15E148 Safari/605.1.15';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
+  });
+
+  it('uses foreground strategy for iOS Opera', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1 OPT/4.7.0';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
+  });
+
+  // Cannot be distinguished from iOS Safari
+  it('uses reload strategy for iOS Brave', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Reload',
+      linkType: 'universal',
+      redirect: true
+    });
+  });
+
+  // Cannot be distinguished from iOS Safari
+  it('uses reload strategy for iOS Edge', function () {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125.0.2535.96 Version/17.0 Mobile/15E148 Safari/604.1';
+
+    expect(determineStrategy(userAgent, undefined)).toStrictEqual({
+      resume: 'Foreground',
+      linkType: 'universal',
+      redirect: false
+    });
   });
 });


### PR DESCRIPTION
the assumption is now that iOS WebKit instances
support universal links as the rule, rather
than the exception.

if we find iOS/browser versions where custom
schemes work better, we will have to adjust.