### PR TITLE
Use PAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ export default function App() {
 
 Always render the `error` field from `useCriiptoVerify`. It surfaces both **configuration errors** (e.g. invalid `domain` or `clientID`, or CORS) raised when the provider mounts, and **runtime errors** raised during a login attempt (e.g. user cancellation, OAuth2 errors from the IdP). Without rendering `error`, misconfiguration and failed logins will appear silent to the user.
 
+## CORS
+
+The library makes fetch requests to Criipto for two reasons:
+
+1. To load application configuration when the provider mounts.
+2. To push the authorization request (PAR) when a user clicks a login button.
+
+Make sure that the origin your React app runs on is included in the list of callback URLs for your application. Otherwise, both calls will fail with CORS errors.
+
 ## Sessions
 
 If you want to use `@criipto/verify-react` for session management (rather than one-off authentication) you can configure a `sessionStore`:
@@ -154,10 +163,6 @@ useEffect(() => {
   loginWithRedirect();
 }, [isLoading, isInitializing]);
 ```
-
-## XHR/fetch caveats
-
-The library may require to do fetch requests against Criipto to fetch application configuration. Make sure that the host that the React app runs on is included in the list of callback URLs for your application. Otherwise, you will encounter CORS errors.
 
 ## Criipto
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import { useCriiptoVerify, AuthMethodSelector } from '@criipto/verify-react';
 import '@criipto/verify-react/index.css';
 
 export default function App() {
-  const { result } = useCriiptoVerify();
+  const { result, error } = useCriiptoVerify();
 
   if (result?.id_token) {
     return <pre>{JSON.stringify(result.id_token, null, 2)}</pre>;
@@ -57,16 +57,14 @@ export default function App() {
 
   return (
     <React.Fragment>
-      {result?.error ? (
-        <p>
-          An error occurred: {result.error} ({result.error_description}). Please try again.
-        </p>
-      ) : null}
+      {error ? <p>An error occurred: {String(error)}. Please try again.</p> : null}
       <AuthMethodSelector />
     </React.Fragment>
   );
 }
 ```
+
+Always render the `error` field from `useCriiptoVerify`. It surfaces both **configuration errors** (e.g. invalid `domain` or `clientID`, or CORS) raised when the provider mounts, and **runtime errors** raised during a login attempt (e.g. user cancellation, OAuth2 errors from the IdP). Without rendering `error`, misconfiguration and failed logins will appear silent to the user.
 
 ## Sessions
 
@@ -102,7 +100,7 @@ You may wish to increase the "Token lifetime" setting of your Criipto Applicatio
 ```jsx
 // src/App.js
 import React from 'react';
-import { useCriiptoVerify, AuthMethodSelector } from '@criipto/verify-react';
+import { useCriiptoVerify, AuthMethodSelector, OAuth2Error } from '@criipto/verify-react';
 
 export default function App() {
   const { claims, error, isLoading } = useCriiptoVerify();
@@ -119,7 +117,11 @@ export default function App() {
     <React.Fragment>
       {error ? (
         <p>
-          An error occured: {error.error} ({error.error_description}). Please try again:
+          An error occured:{' '}
+          {error instanceof OAuth2Error
+            ? `${error.error} (${error.error_description})`
+            : String(error)}
+          . Please try again.
         </p>
       ) : null}
       <AuthMethodSelector />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
-        "@criipto/auth-js": "^3.7.2",
+        "@criipto/auth-js": "^4.0.3",
         "@ua-parser-js/pro-enterprise": "^2.0.9",
         "classnames": "^2.5.1",
         "jwt-decode": "^3.1.2",
@@ -390,9 +390,10 @@
       }
     },
     "node_modules/@criipto/auth-js": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-3.7.2.tgz",
-      "integrity": "sha512-RHkFSh8nLy27Uku7ADsgDRML+fJBCi7CqsIGYDHzca4qah0Wn4BdWGEWhvMrpOzdHIbeQzaIuViTFPW99r2+jA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-4.0.3.tgz",
+      "integrity": "sha512-xWQ93Wv9vjHNPoY2DWIzV93wtEa47jwhtc0ZPfmGtDFBIl3JKqPUic3eMONC5THcOz2NYokSe/OfimSbuSJztw==",
+      "license": "MIT",
       "dependencies": {
         "jose": "^4.15.5",
         "qrcode": "^1.5.1"
@@ -3818,9 +3819,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7021,9 +7023,9 @@
       }
     },
     "@criipto/auth-js": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-3.7.2.tgz",
-      "integrity": "sha512-RHkFSh8nLy27Uku7ADsgDRML+fJBCi7CqsIGYDHzca4qah0Wn4BdWGEWhvMrpOzdHIbeQzaIuViTFPW99r2+jA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@criipto/auth-js/-/auth-js-4.0.3.tgz",
+      "integrity": "sha512-xWQ93Wv9vjHNPoY2DWIzV93wtEa47jwhtc0ZPfmGtDFBIl3JKqPUic3eMONC5THcOz2NYokSe/OfimSbuSJztw==",
       "requires": {
         "jose": "^4.15.5",
         "qrcode": "^1.5.1"
@@ -8943,9 +8945,9 @@
       }
     },
     "jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg=="
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "homepage": "https://github.com/criipto/criipto-verify-react#readme",
   "dependencies": {
-    "@criipto/auth-js": "^3.7.2",
+    "@criipto/auth-js": "^4.0.3",
     "classnames": "^2.5.1",
     "jwt-decode": "^3.1.2",
     "qrcode": "^1.5.4",

--- a/src/components/AuthButtonGroup.tsx
+++ b/src/components/AuthButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import React, { createContext, useState } from 'react';
 import {
   AuthMethodButtonContainer,
   type AuthMethodButtonContainerProps,
@@ -10,10 +10,14 @@ import SEBankIDQrCode from './SEBankIDQRCode';
 interface AuthButtonGroupContextInterface {
   multiple: boolean;
   acrValues: string[];
+  disabled: boolean;
+  setDisabled: (disabled: boolean) => void;
 }
 const initialContext: AuthButtonGroupContextInterface = {
   multiple: false,
   acrValues: [],
+  disabled: false,
+  setDisabled: () => {},
 };
 export const AuthButtonGroupContext =
   createContext<AuthButtonGroupContextInterface>(initialContext);
@@ -36,10 +40,13 @@ export default function AuthButtonGroup(props: { children: React.ReactNode }) {
     }
     return [];
   });
+  const [disabled, setDisabled] = useState(false);
 
   const context: AuthButtonGroupContextInterface = {
     multiple: acrValues.length > 1,
     acrValues,
+    disabled,
+    setDisabled,
   };
   return (
     <AuthButtonGroupContext.Provider value={context}>

--- a/src/components/AuthMethodButton.tsx
+++ b/src/components/AuthMethodButton.tsx
@@ -108,37 +108,19 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
   const group = useContext(AuthButtonGroupContext);
   const standalone = !group.multiple || isSingle(props.acrValue, group.acrValues);
   const context = useContext(CriiptoVerifyContext);
-  const { buildAuthorizeUrl } = context;
+  const { initializePAR } = context;
   const language = (props.language ?? context.uiLocales ?? 'en') as Language;
   const action = (props.action ?? context.action ?? 'login') as Action;
   const className = `criipto-eid-btn ${acrValueToClassName(acrValue)}${
     props.className ? ` ${props.className}` : ''
   }`;
   const [backdrop, setBackdrop] = useState<React.ReactElement | null>(null);
-
-  const [href, setHref] = useState(props.href);
-  const redirectUri = props.redirectUri || context.redirectUri;
-
+  const [loading, setLoading] = useState<boolean>(props.loading ?? false);
   useEffect(() => {
-    if (props.href) return;
+    setLoading(props.loading ?? false);
+  }, [props.loading]);
 
-    let isSubscribed = true;
-    let loginHint: string | undefined = undefined;
-
-    buildAuthorizeUrl({
-      redirectUri,
-      acrValues: acrValue,
-      loginHint,
-    })
-      .then((href) => {
-        if (isSubscribed) setHref(href);
-      })
-      .catch(console.error);
-
-    return () => {
-      isSubscribed = false;
-    };
-  }, [props.href, buildAuthorizeUrl, acrValue, context.pkce, redirectUri]);
+  const redirectUri = props.redirectUri || context.redirectUri;
 
   const handleClick: React.MouseEventHandler = (event) => {
     if (props.href) return;
@@ -182,11 +164,28 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
     }
 
     if (props.onClick) props.onClick(event);
+
+    if (!event.isDefaultPrevented()) {
+      setLoading(true);
+      initializePAR({
+        redirectUri,
+        acrValues: acrValue,
+        loginHint: '',
+      })
+        .then((authorizeUrl) => {
+          window.location.href = authorizeUrl.toString();
+        })
+        .catch((error) => {
+          setLoading(false);
+          context.handleResponse(error);
+        });
+    }
   };
 
   const { title, subtitle } = acrValueToTitle(language, acrValue, {
     disambiguate: isAmbiguous(acrValue, group.acrValues),
   });
+
   const contents = props.children ?? (
     <React.Fragment>
       {stringifyAction(language, action) ? `${stringifyAction(language, action)} ` : ''}
@@ -199,9 +198,9 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
     <React.Fragment>
       <AuthMethodButtonComponent
         {...props}
-        href={href}
         className={className}
         onClick={handleClick}
+        loading={loading}
       />
       {backdrop}
     </React.Fragment>

--- a/src/components/AuthMethodButton.tsx
+++ b/src/components/AuthMethodButton.tsx
@@ -51,8 +51,10 @@ export function AuthMethodButtonComponent(props: AuthMethodButtonComponentProps)
   const standalone = !group.multiple || isSingle(props.acrValue, group.acrValues);
   const language = (props.language ?? 'en') as Language;
   const action = (props.action ?? 'login') as Action;
+
+  const disabled = (props.disabled || group.disabled) && !props.loading;
   const className = classNames(`criipto-eid-btn`, acrValueToClassName(acrValue), props.className, {
-    'criipto-eid-btn--disabled': props.disabled,
+    'criipto-eid-btn--disabled': disabled,
     'criipto-eid-btn--loading': props.loading,
   });
 
@@ -74,17 +76,20 @@ export function AuthMethodButtonComponent(props: AuthMethodButtonComponentProps)
     </React.Fragment>
   );
 
+  const commonProps = {
+    ...props,
+    className,
+    disabled,
+  };
   const button = href ? (
     <React.Fragment>
-      <AnchorButton {...props} href={href} className={className} onClick={props.onClick}>
+      <AnchorButton {...commonProps} href={href}>
         {inner}
       </AnchorButton>
     </React.Fragment>
   ) : (
     <React.Fragment>
-      <Button {...props} className={className} onClick={props.onClick}>
-        {inner}
-      </Button>
+      <Button {...commonProps}>{inner}</Button>
     </React.Fragment>
   );
 
@@ -167,6 +172,7 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
 
     if (!event.isDefaultPrevented()) {
       setLoading(true);
+      group.setDisabled(true);
       initializePAR({
         redirectUri,
         acrValues: acrValue,
@@ -177,6 +183,7 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
         })
         .catch((error) => {
           setLoading(false);
+          group.setDisabled(false);
           context.handleResponse(error);
         });
     }
@@ -214,6 +221,7 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
         className={className}
         userAgent={props.userAgent}
         logo={<AuthMethodButtonLogo acrValue={acrValue} logo={props.logo} />}
+        disabled={props.disabled}
       >
         <span>{contents}</span>
       </SEBankIDSameDeviceButton>

--- a/src/components/QRCode.tsx
+++ b/src/components/QRCode.tsx
@@ -1,5 +1,10 @@
-import { OAuth2Error, savePKCEState, UserCancelledError } from '@criipto/auth-js';
-import type CriiptoConfiguration from '@criipto/auth-js/dist/CriiptoConfiguration';
+import {
+  OAuth2Error,
+  savePKCEState,
+  UserCancelledError,
+  type CriiptoConfiguration,
+} from '@criipto/auth-js';
+
 import React, {
   useContext,
   useRef,

--- a/src/components/SEBankIDSameDeviceButton.tsx
+++ b/src/components/SEBankIDSameDeviceButton.tsx
@@ -8,6 +8,8 @@ import ForegroundStrategy from './SEBankIDSameDeviceButton/Foreground';
 import ReloadStrategy from './SEBankIDSameDeviceButton/Reload';
 
 import { autoHydratedState, type Links } from './SEBankIDSameDeviceButton/shared';
+import { AuthButtonGroupContext } from './AuthButtonGroup';
+import classNames from 'classnames';
 import { Spinner } from './Spinner/Spinner';
 
 interface Props {
@@ -17,6 +19,7 @@ interface Props {
   fallback: React.ReactElement;
   redirectUri?: string;
   userAgent?: string;
+  disabled?: boolean;
 }
 
 function searchParamsToPOJO(input: URLSearchParams) {
@@ -79,6 +82,8 @@ async function fetchComplete(completeUrl: string) {
 }
 export default function SEBankIDSameDeviceButton(props: Props) {
   const { loginHint } = useContext(CriiptoVerifyContext);
+  const group = useContext(AuthButtonGroupContext);
+
   const rawUserAgent = typeof navigator !== 'undefined' ? navigator.userAgent : props.userAgent;
   const strategy = useMemo(
     () => determineStrategy(rawUserAgent, loginHint),
@@ -100,6 +105,8 @@ export default function SEBankIDSameDeviceButton(props: Props) {
     domain,
   } = useContext(CriiptoVerifyContext);
   const redirectUri = props.redirectUri || defaultRedirectURi;
+
+  const disabled = props.disabled || group.disabled || initiated;
 
   const reset = () => {
     setPKCE(undefined);
@@ -212,12 +219,14 @@ export default function SEBankIDSameDeviceButton(props: Props) {
 
   // Track when the button is clicked to stop refreshing URL
   const handleInitiate = () => {
+    group.setDisabled(true);
     handleLog('Initiated');
     setInitiated(true);
     setError(null);
   };
 
   const handleError = async (error: string) => {
+    group.setDisabled(false);
     setInitiated(false);
     setError(error);
 
@@ -237,7 +246,7 @@ export default function SEBankIDSameDeviceButton(props: Props) {
 
   const element = href ? (
     <a
-      className={`${props.className} ${initiated ? 'criipto-eid-btn--disabled' : ''}`}
+      className={classNames(props.className, { 'criipto-eid-btn--disabled': disabled })}
       href={href}
       onClick={handleInitiate}
     >

--- a/src/context.ts
+++ b/src/context.ts
@@ -40,13 +40,14 @@ export interface CriiptoVerifyContextInterface {
   logout: (params?: { redirectUri?: string; state?: string }) => Promise<void>;
   fetchOpenIDConfiguration: () => Promise<OpenIDConfiguration>;
   buildAuthorizeUrl: (options?: AuthorizeUrlParamsOptional) => Promise<string>;
+  initializePAR: (options?: AuthorizeUrlParamsOptional) => Promise<URL>;
   generatePKCE: () => Promise<PKCE | undefined>;
   buildOptions: (
     options?: AuthorizeUrlParamsOptional | RedirectAuthorizeParams,
   ) => AuthorizeUrlParamsOptional;
   handleResponse: (
-    response: AuthorizeResponse,
-    params: { pkce?: PKCE; redirectUri?: string; source?: ResultSource },
+    response: AuthorizeResponse | (Error | OAuth2Error),
+    params?: { pkce?: PKCE; redirectUri?: string; source?: ResultSource },
   ) => Promise<void>;
   responseType: 'token' | 'code';
   completionStrategy: 'client' | 'openidprovider';
@@ -83,6 +84,7 @@ const initialContext = {
   logout: stub,
   fetchOpenIDConfiguration: stub,
   buildAuthorizeUrl: stub,
+  initializePAR: stub,
   generatePKCE: stub,
   buildOptions: stub,
   handleResponse: stub,

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ import CriiptoAuth, {
   OAuth2Error,
   type PKCEPublicPart,
 } from '@criipto/auth-js';
-import type { PopupAuthorizeParams, RedirectAuthorizeParams } from '@criipto/auth-js/dist/types';
+import type { PopupAuthorizeParams, RedirectAuthorizeParams } from '@criipto/auth-js';
 import { createContext } from 'react';
 
 export type ResultSource =

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,1 @@
-@import '@criipto/auth-js/dist/index.css';
+@import '../node_modules/@criipto/auth-js/dist/index.css';

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -305,10 +305,19 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
     [client, buildOptions],
   );
 
+  const initializePAR = useCallback(
+    async (options?: AuthorizeUrlParamsOptional) => {
+      return (
+        await client.pushAuthorizationRequest(client.buildAuthorizeParams(buildOptions(options)))
+      ).authorizeUrl;
+    },
+    [client, buildOptions],
+  );
+
   const handleResponse = useCallback(
     async (
       response: AuthorizeResponse | (Error | OAuth2Error),
-      params: { pkce?: PKCE; redirectUri?: string; source?: ResultSource },
+      params: { pkce?: PKCE; redirectUri?: string; source?: ResultSource } = {},
     ) => {
       if (response instanceof OAuth2Error) {
         setResult(response);
@@ -404,6 +413,7 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
       logout,
       fetchOpenIDConfiguration: () => client.fetchOpenIDConfiguration(),
       buildAuthorizeUrl,
+      initializePAR,
       generatePKCE: async () => {
         if (responseType !== 'token' || completionStrategy !== 'client') return;
         return await generatePKCE();

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -19,11 +19,7 @@ import CriiptoVerifyContext, {
   actions,
   type ResultSource,
 } from './context';
-import type {
-  AuthorizeResponse,
-  RedirectAuthorizeParams,
-  ResponseType,
-} from '@criipto/auth-js/dist/types';
+import type { AuthorizeResponse, RedirectAuthorizeParams, ResponseType } from '@criipto/auth-js';
 
 import { filterAcrValues, trySessionStorage, VERSION } from './utils';
 import jwtDecode from 'jwt-decode';

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -224,6 +224,24 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
   }, [client]);
 
   const [result, setResult] = useState<Result | null>(null);
+
+  // Verify that domain and client id are valid; surface failures as the hook's `error`.
+  useEffect(() => {
+    let isSubscribed = true;
+    (async () => {
+      try {
+        await client.fetchCriiptoConfiguration();
+      } catch (error) {
+        if (!isSubscribed) return;
+        const err = error instanceof Error ? error : new Error(String(error));
+        setResult((prev) => prev ?? err);
+      }
+    })();
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, [client]);
   const claims = useMemo(() => {
     if (!result) return null;
     if (!('id_token' in result)) return null;

--- a/src/use-criipto-verify.ts
+++ b/src/use-criipto-verify.ts
@@ -20,7 +20,14 @@ export default function useCriiptoVerify() {
      * The claims of the decoded id_token (if available)
      */
     claims,
-    error: result && 'error' in result ? result : null,
+    /**
+     * Set when the provider failed to fetch configuration (e.g. invalid `domain`/`clientID`,
+     * or CORS), or when an authentication attempt failed (e.g. user cancellation, OAuth2 errors
+     * from the IdP). Always render this in your UI — failures are otherwise silent.
+     *
+     * `OAuth2Error` for IdP-returned errors, `Error` for everything else.
+     */
+    error: result && ('error' in result || result instanceof Error) ? result : null,
     loginWithRedirect,
     loginWithPopup,
     acrValues,


### PR DESCRIPTION
This should probably be considered a breaking change, since the PAR request is susceptible to CORS. So if you start on `https://login.example.com`, and the redirect URL is `https://app.example.com`, and only `https://app.example.com` is allowed as redirect URL - the PAR request will be blocked by CORS.