### PR TITLE
Remove is mounted checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
         "vitest": "^4.0.18"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17 || ^18 || ^19",
-        "react-dom": "^16.11.0 || ^17 || ^18 || ^19"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "prepare": "husky"
   },
   "peerDependencies": {
-    "react": "^16.11.0 || ^17 || ^18 || ^19",
-    "react-dom": "^16.11.0 || ^17 || ^18 || ^19"
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
   },
   "devDependencies": {
     "@storybook/react": "^10.3.0",

--- a/src/components/AuthMethodButton.tsx
+++ b/src/components/AuthMethodButton.tsx
@@ -117,23 +117,13 @@ export function AuthMethodButtonContainer(props: AuthMethodButtonContainerProps)
   useEffect(() => {
     if (props.href) return;
 
-    let isSubscribed = true;
-    let loginHint: string | undefined = undefined;
-
     buildAuthorizeUrl({
       redirectUri,
       acrValues: acrValue,
-      loginHint,
     })
-      .then((href) => {
-        if (isSubscribed) setHref(href);
-      })
+      .then(setHref)
       .catch(console.error);
-
-    return () => {
-      isSubscribed = false;
-    };
-  }, [props.href, buildAuthorizeUrl, acrValue, context.pkce, redirectUri]);
+  }, [props.href, setHref, buildAuthorizeUrl, acrValue, context.pkce, redirectUri]);
 
   const handleClick: React.MouseEventHandler = (event) => {
     if (props.href) return;

--- a/src/components/QRCode.tsx
+++ b/src/components/QRCode.tsx
@@ -60,16 +60,7 @@ const QRCode: React.FC<{
   const acrValues = props.acrValues ?? configurationAcrValues ?? [];
 
   useEffect(() => {
-    let isSubsribed = true;
-
-    client.fetchCriiptoConfiguration().then((c) => {
-      if (!isSubsribed) return;
-      setCriiptoConfiguration(c);
-    });
-
-    return () => {
-      isSubsribed = false;
-    };
+    client.fetchCriiptoConfiguration().then(setCriiptoConfiguration);
   }, [client]);
 
   const redirect = useCallback(async () => {

--- a/src/components/SEBankIDQRCode.tsx
+++ b/src/components/SEBankIDQRCode.tsx
@@ -235,7 +235,6 @@ export function useDraw(qrCode: string | null, options: UseDrawOptions) {
   useEffect(() => {
     if (!qrCode) return;
 
-    let isSubscribed = true;
     (async () => {
       const qrImage = await QRCode.toDataURL(qrCode, {
         errorCorrectionLevel: 'low',
@@ -244,13 +243,8 @@ export function useDraw(qrCode: string | null, options: UseDrawOptions) {
         margin: qrMargin ?? 4,
       });
 
-      if (!isSubscribed) return;
       setDataURL(qrImage);
     })();
-
-    return () => {
-      isSubscribed = false;
-    };
   }, [qrCode, qrMargin, width]);
 
   return dataURL;
@@ -270,12 +264,9 @@ export function usePoll(pollUrl: string | null, options: UsePollOptions) {
 
     const delay = 2500;
     let timeout: any;
-    let isSubscribed = true;
     const poll = async () => {
-      if (!isSubscribed) return;
       const response = await fetch(pollUrl);
 
-      if (!isSubscribed) return;
       if (response.status < 400) {
         const payload = (await response.json()) as PollResponse;
         if (payload.qrCode) onQrCode(payload.qrCode);
@@ -295,7 +286,6 @@ export function usePoll(pollUrl: string | null, options: UsePollOptions) {
 
     timeout = setTimeout(poll, delay);
     return () => {
-      isSubscribed = false;
       clearTimeout(timeout);
     };
   }, [pollUrl, onQrCode, onComplete, onError, enabled]);

--- a/src/components/SEBankIDSameDeviceButton/usePoll.ts
+++ b/src/components/SEBankIDSameDeviceButton/usePoll.ts
@@ -10,31 +10,23 @@ export interface UsePollProps {
 export function usePoll({ shouldPoll, pollUrl, onComplete, onError }: UsePollProps) {
   useEffect(() => {
     if (!shouldPoll) return;
-    let isSubscribed = true;
     let timeout: string | undefined;
     const poll = async () => {
-      if (!isSubscribed) return;
       const response = await fetch(pollUrl);
 
       if (response.status === 202) {
         setTimeout(poll, 1000);
-        return;
       } else if (response.status >= 400) {
-        if (!isSubscribed) return;
         const error = await response.text();
         onError(error);
-        return;
       } else {
-        if (!isSubscribed) return;
         const { targetUrl } = await response.json();
         onComplete(targetUrl);
-        return;
       }
     };
 
     setTimeout(poll, 1000);
     return () => {
-      isSubscribed = false;
       if (timeout) clearTimeout(timeout);
     };
   }, [shouldPoll, pollUrl]);

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -216,15 +216,7 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
 
   const [configuration, setConfiguration] = useState<OpenIDConfiguration | null>(null);
   useEffect(() => {
-    let isSubscribed = true;
-    (async () => {
-      const configuration = await client.fetchOpenIDConfiguration();
-      if (isSubscribed) setConfiguration(configuration);
-    })();
-
-    return () => {
-      isSubscribed = false;
-    };
+    client.fetchOpenIDConfiguration().then(setConfiguration);
   }, [client]);
 
   const [result, setResult] = useState<Result | null>(null);
@@ -460,7 +452,6 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
       return;
     }
 
-    let isSubscribed = true;
     setIsLoading(true);
 
     const params = parseAuthorizeResponseFromLocation(window.location);
@@ -473,11 +464,9 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
 
     (async () => {
       await Promise.resolve(); // wait for the initial cleanup in Strict mode - avoids double mutation
-      if (!isSubscribed) return;
 
       try {
         const response = await client.redirect.match();
-        if (!isSubscribed) return;
 
         if (response?.code) {
           setResult({ code: response.code, source: 'redirect', state: response.state });
@@ -487,7 +476,6 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
           resetRedirectState(window);
         } else setResult(null);
       } catch (err: any) {
-        if (!isSubscribed) return;
         if (err instanceof OAuth2Error) {
           setResult(err);
         } else if (err instanceof Error) {
@@ -496,15 +484,10 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
           setResult(new Error(err?.toString() ?? 'Unknown error ocurred'));
         }
       } finally {
-        if (!isSubscribed) return;
         setIsLoading(false);
         refreshPKCE(); // Clear out session storage and recreate PKCE values if being used
       }
     })();
-
-    return () => {
-      isSubscribed = false;
-    };
   }, [props.pkce, responseType]);
 
   /*
@@ -549,7 +532,6 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
     if (!sessionStore) return;
     if (client.redirect.hasMatch()) return; // Do not issue SSO check if we're just being redirected back to
     if (sessionStore.getItem(SESSION_KEY)) return;
-    let isSubscribed = true;
 
     setIsLoading(true);
     checkSession()
@@ -557,12 +539,8 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions): React.React
         console.error('session silent check error', err);
       })
       .finally(() => {
-        if (isSubscribed) setIsLoading(false);
+        setIsLoading(false);
       });
-
-    return () => {
-      isSubscribed = false;
-    };
   }, [sessionStore, client]);
 
   return (


### PR DESCRIPTION
I stumbled upon https://github.com/facebook/react/pull/22114 while reading up on something else. Removing mounted checks makes our code significantly easier to follow.

This will require us to drop support for react < 18, so we don't start logging excessive warnings to consumers. But I think that's fine since react 18 is four years old, and we will need a major bump for PAR anyway.