### PR TITLE
fix: let auth method buttons grow to fit wrapped text

### DIFF
--- a/src/components/AuthMethodButton/AuthMethodButton.css
+++ b/src/components/AuthMethodButton/AuthMethodButton.css
@@ -1,6 +1,6 @@
 .criipto-eid-btn {
   padding: 6px 24px 6px 16px;
-  height: 60px;
+  min-height: 60px;
   box-sizing: border-box;
   text-decoration: none;
   border: 0;


### PR DESCRIPTION
## Summary
- Auth method buttons (e.g. "Login med MitID") used a fixed `height: 60px`, so when users zoomed in or enlarged their font the wrapped label overflowed the button and bled into the button below.
- Switched the rule to `min-height: 60px`, preserving the default appearance while letting the flexbox button grow vertically to contain wrapped text.
